### PR TITLE
add user groups

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,12 @@
     line-height: 1.2;
 }
 
+.display-6 {
+    font-size: 2rem;
+    font-weight: 300;
+    line-height: 1.2;
+}
+
 .container {
   margin-top: 10px;
 }

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,0 +1,23 @@
+class MembershipsController < ApplicationController
+  before_action :set_user_group, only: %i[create destroy]
+
+  def create
+    @membership = @user_group.memberships.new user_id: current_user.id
+    if @membership.save
+      redirect_to @user_group, notice: 'Group was successfully joined.'
+    else
+      redirect_to @user_group, flash: { error: 'Group was not joined.' }
+    end
+  end
+
+  def destroy
+    Membership.find(params[:id]).destroy
+    redirect_to @user_group, notice: 'Group was successfully left.'
+  end
+
+  private
+
+  def set_user_group
+    @user_group = UserGroup.find params[:user_group_id]
+  end
+end

--- a/app/controllers/user_groups_controller.rb
+++ b/app/controllers/user_groups_controller.rb
@@ -1,0 +1,44 @@
+class UserGroupsController < ApplicationController
+  before_action :set_user_group, only: %i[show edit update]
+
+  def index
+    @user_groups = UserGroup.all
+  end
+
+  def show
+    @membership = @user_group.memberships.find_by(user_id: current_user.id)
+  end
+
+  def new
+    @user_group = UserGroup.new
+  end
+
+  def create
+    @user_group = UserGroup.new(user_group_params).tap do |user_group|
+      user_group.users << current_user
+    end
+    if @user_group.save
+      redirect_to @user_group, notice: 'User group was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @user_group.update(user_group_params)
+      redirect_to @user_group, notice: 'User group was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_user_group
+    @user_group = UserGroup.find(params[:id])
+  end
+
+  def user_group_params
+    params.require(:user_group).permit(:name, :description)
+  end
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,6 @@
+class Membership < ApplicationRecord
+  belongs_to :user
+  belongs_to :user_group
+
+  validates :user, :user_group, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   has_many :started_conversations, class_name: 'Conversation', foreign_key: 'user_id', dependent: :destroy
   has_many :participated_conversations, class_name: 'Conversation', foreign_key: 'participant_id', dependent: :destroy
   has_many :messages, dependent: :destroy
+  has_many :memberships, dependent: :destroy
+  has_many :user_groups, through: :memberships
 
   validates :name, presence: true
 

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -1,0 +1,4 @@
+class UserGroup < ApplicationRecord
+  has_many :memberships, dependent: :destroy
+  has_many :users, through: :memberships
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,6 +20,10 @@
                 - if Message.unread_by(current_user).length > 0
                   %span.badge.badge-danger
                     = Message.unread_by(current_user).count
+            %li.nav-item.active
+              = link_to 'Users', users_path, class: 'nav-link'
+            %li.nav-item.active
+              = link_to 'Groups', user_groups_path, class: 'nav-link'
           = search_form_for @q, class: 'form-inline my-2 my-lg-0' do |f|
             .input-group
               = f.text_field :name_cont, class: 'form-control', placeholder: 'Search', type: 'search'

--- a/app/views/user_groups/_form.html.haml
+++ b/app/views/user_groups/_form.html.haml
@@ -1,0 +1,32 @@
+= form_for @user_group do |f|
+  - if @user_group.errors.any?
+    #error_explanation
+      %h2= "#{pluralize(@user_group.errors.count, "error")} prohibited this user_group from being saved:"
+      %ul
+        - @user_group.errors.full_messages.each do |message|
+          %li= message
+
+  .form-group
+    = f.text_field :name, class: 'form-control form-control-lg', placeholder: 'Name'
+  .form-group
+    = f.text_area :description, class: 'form-control form-control-lg', placeholder: 'Description'
+  .form-group
+    = f.submit 'Save', class: 'btn btn-light'
+
+-# %h1.display-4
+-#   = link_to 'Log in', new_session_path(resource_name)
+-#   \/ Sign up
+-# = form_for resource, as: resource_name, url: registration_path(resource_name) do |f|
+-#   = devise_error_messages!
+-#   .form-group
+-#     = f.text_field :name, autofocus: true, class: 'form-control form-control-lg', placeholder: 'Name'
+-#   .form-group
+-#     = f.email_field :email, class: 'form-control form-control-lg', placeholder: 'Email'
+-#   .form-group
+-#     = f.password_field :password, autocomplete: 'off', class: 'form-control form-control-lg', placeholder: 'Password'
+-#     - if @minimum_password_length
+-#       %small.form-text.text-muted #{@minimum_password_length} characters minimum
+-#   .form-group
+-#     = f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control form-control-lg', placeholder: 'Confirm password'
+-#   .form-group
+-#     = f.submit 'Sign up', class: 'btn btn-light'

--- a/app/views/user_groups/_table.html.haml
+++ b/app/views/user_groups/_table.html.haml
@@ -1,0 +1,6 @@
+%table.table.table-striped
+  %tbody
+    - user_groups.each do |user_group|
+      %tr
+        %td.td-link{width: 10}
+          = link_to user_group.name, user_group

--- a/app/views/user_groups/edit.html.haml
+++ b/app/views/user_groups/edit.html.haml
@@ -1,0 +1,10 @@
+%nav{role: 'navigation'}
+  %ol.breadcrumb
+    %li.breadcrumb-item= link_to 'All groups', user_groups_path
+    %li.breadcrumb-item= link_to @user_group.name, @user_group
+    %li.breadcrumb-item.active Edit
+
+%h1.display-5
+  Edit #{@user_group.name}
+
+= render 'form'

--- a/app/views/user_groups/index.html.haml
+++ b/app/views/user_groups/index.html.haml
@@ -1,0 +1,9 @@
+%h1.display-4
+  Groups
+  = link_to new_user_group_path, class: 'btn btn-light' do
+    = fa_icon 'plus', text: 'New'
+
+- if @user_groups.length > 0
+  = render partial: 'table', locals: {user_groups: @user_groups}
+- else
+  No groups found...

--- a/app/views/user_groups/new.html.haml
+++ b/app/views/user_groups/new.html.haml
@@ -1,0 +1,9 @@
+%nav{role: 'navigation'}
+  %ol.breadcrumb
+    %li.breadcrumb-item= link_to 'All groups', user_groups_path
+    %li.breadcrumb-item.active New
+
+%h1.display-5
+  New Group
+
+= render 'form'

--- a/app/views/user_groups/show.html.haml
+++ b/app/views/user_groups/show.html.haml
@@ -1,0 +1,23 @@
+%nav{role: 'navigation'}
+  %ol.breadcrumb
+    %li.breadcrumb-item= link_to 'All groups', user_groups_path
+    %li.breadcrumb-item.active #{@user_group.name}
+
+%h1.display-5
+  = @user_group.name
+  - if @membership
+    = link_to edit_user_group_path(@user_group), class: 'btn btn-light' do
+      = fa_icon 'pencil', text: 'Edit'
+    = link_to user_group_membership_path(@user_group, @membership), method: :delete, class: 'btn btn-light' do
+      = fa_icon 'times', text: 'Leave'
+  - else
+    = link_to user_group_memberships_path(@user_group), method: :post, class: 'btn btn-light' do
+      = fa_icon 'plus', text: 'Join'
+
+%p
+  Created #{time_ago_in_words @user_group.created_at} ago.
+
+%p= @user_group.description
+
+%h1.display-6 Users
+= render partial: 'users/table', locals: {users: @user_group.users}

--- a/app/views/users/_table.html.haml
+++ b/app/views/users/_table.html.haml
@@ -1,0 +1,6 @@
+%table.table.table-striped
+  %tbody
+    - users.each do |user|
+      %tr
+        %td.td-link{width: 10}
+          = link_to user.name, user

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,11 +1,6 @@
 %h1.display-4 Users
 
 - if @users.length > 0
-  %table.table.table-striped
-    %tbody
-      - @users.each do |user|
-        %tr
-          %td.td-link{width: 10}
-            = link_to user.name, user
+  = render partial: 'table', locals: {users: @users}
 - else
   No users found...

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -10,3 +10,6 @@
 
 %p
   Member since #{time_ago_in_words @user.created_at}.
+
+%h1.display-6 Groups
+= render partial: 'user_groups/table', locals: {user_groups: @user.user_groups}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,8 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: %i[index show]
+
+  resources :user_groups, except: :destroy do
+    resources :memberships, only: %i[create destroy]
+  end
 end

--- a/db/migrate/20171123140450_create_user_groups.rb
+++ b/db/migrate/20171123140450_create_user_groups.rb
@@ -1,0 +1,10 @@
+class CreateUserGroups < ActiveRecord::Migration[5.1]
+  def change
+    create_table :user_groups do |t|
+      t.string :name, index: true, null: false, default: ''
+      t.text :description, null: false, default: ''
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171123140659_create_memberships.rb
+++ b/db/migrate/20171123140659_create_memberships.rb
@@ -1,0 +1,10 @@
+class CreateMemberships < ActiveRecord::Migration[5.1]
+  def change
+    create_table :memberships do |t|
+      t.references :user, foreign_key: true, index: true
+      t.references :user_group, foreign_key: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171116105507) do
+ActiveRecord::Schema.define(version: 20171123140659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 20171116105507) do
     t.index ["user_id"], name: "index_conversations_on_user_id"
   end
 
+  create_table "memberships", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "user_group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_group_id"], name: "index_memberships_on_user_group_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
   create_table "messages", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "conversation_id"
@@ -34,6 +43,14 @@ ActiveRecord::Schema.define(version: 20171116105507) do
     t.datetime "updated_at", null: false
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "user_groups", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.text "description", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_user_groups_on_name"
   end
 
   create_table "users", force: :cascade do |t|
@@ -55,6 +72,8 @@ ActiveRecord::Schema.define(version: 20171116105507) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "memberships", "user_groups"
+  add_foreign_key "memberships", "users"
   add_foreign_key "messages", "conversations"
   add_foreign_key "messages", "users"
 end

--- a/test/controllers/memberships_controller_test.rb
+++ b/test/controllers/memberships_controller_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class MembershipsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in users(:alice)
+
+    @membership = memberships(:one)
+    @user_group = @membership.user_group
+  end
+
+  test 'should create membership' do
+    assert_difference('Membership.count') do
+      post user_group_memberships_path(@user_group)
+    end
+
+    assert_redirected_to user_group_url(Membership.last.user_group)
+  end
+
+  test 'should destroy membership' do
+    assert_difference('Membership.count', -1) do
+      delete user_group_membership_url(@user_group, @membership)
+    end
+
+    assert_redirected_to user_group_url(@user_group)
+  end
+end

--- a/test/controllers/user_groups_controller_test.rb
+++ b/test/controllers/user_groups_controller_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class UserGroupsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user_group = user_groups(:one)
+    @current_user = users(:alice)
+    sign_in @current_user
+  end
+
+  test 'should get index' do
+    get user_groups_url
+    assert_response :success
+  end
+
+  test 'should get new' do
+    get new_user_group_url
+    assert_response :success
+  end
+
+  test 'should create user_group' do
+    assert_difference('UserGroup.count') do
+      post user_groups_url, params: { user_group: { description: @user_group.description, name: @user_group.name } }
+    end
+
+    assert_includes UserGroup.last.users, @current_user
+    assert_redirected_to user_group_url(UserGroup.last)
+  end
+
+  test 'should show user_group' do
+    get user_group_url(@user_group)
+    assert_response :success
+  end
+
+  test 'should get edit' do
+    get edit_user_group_url(@user_group)
+    assert_response :success
+  end
+
+  test 'should update user_group' do
+    patch user_group_url(@user_group), params: { user_group: { description: @user_group.description, name: @user_group.name } }
+    assert_redirected_to user_group_url(@user_group)
+  end
+end

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: alice
+  user_group: one
+
+two:
+  user: alice
+  user_group: two

--- a/test/fixtures/user_groups.yml
+++ b/test/fixtures/user_groups.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyText
+
+two:
+  name: MyString
+  description: MyText

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class MembershipTest < ActiveSupport::TestCase
+  test 'valid' do
+    assert memberships('one').valid?
+  end
+
+  test 'invalid without user' do
+    refute Membership.new(user_group: user_groups('one')).valid?
+  end
+
+  test 'invalid without user group' do
+    refute Membership.new(user: users('alice')).valid?
+  end
+end

--- a/test/models/user_group_test.rb
+++ b/test/models/user_group_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class UserGroupTest < ActiveSupport::TestCase
+end

--- a/test/system/memberships_test.rb
+++ b/test/system/memberships_test.rb
@@ -1,0 +1,4 @@
+require 'application_system_test_case'
+
+class MembershipsTest < ApplicationSystemTestCase
+end

--- a/test/system/user_groups_test.rb
+++ b/test/system/user_groups_test.rb
@@ -1,0 +1,27 @@
+require 'application_system_test_case'
+
+class UserGroupsTest < ApplicationSystemTestCase
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user_group = user_groups(:one)
+    sign_in users(:alice)
+  end
+
+  test 'visiting the index page' do
+    visit user_groups_url
+    assert_selector 'h1', text: 'Groups'
+    assert_selector 'table'
+  end
+
+  test 'visiting a user group page' do
+    visit user_group_url @user_group
+    assert_selector 'h1', text: @user_group.name
+  end
+
+  test 'visiting a user group edit page' do
+    visit edit_user_group_url @user_group
+    assert_selector 'h1', text: "Edit #{@user_group.name}"
+    assert_selector 'form'
+  end
+end


### PR DESCRIPTION
- everyone can create/edit a user group
- groups will be used to restrict access to data sources
- a user can have multiple groups and a group can have multiples users

in the future for security reasons we could:
-  restrict edit access to specific members
- enable private mode to restrict access to a group

![screen shot 2017-11-24 at 5 44 47 pm](https://user-images.githubusercontent.com/6973663/33218840-5bccaf60-d13f-11e7-991a-5d6be15cf8f0.png)
![screen shot 2017-11-24 at 5 44 56 pm](https://user-images.githubusercontent.com/6973663/33218842-5be55ee8-d13f-11e7-94e5-9dcb2d2cef6f.png)
![screen shot 2017-11-24 at 5 45 07 pm](https://user-images.githubusercontent.com/6973663/33218843-5bfba48c-d13f-11e7-9461-241006cb1903.png)
