### PR TITLE
add visibility to user groups

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -18,7 +18,7 @@ class MembershipsController < ApplicationController
 
   def destroy
     Membership.find(params[:id]).destroy
-    redirect_back fallback_location: @user_group, notice: 'Group was successfully left.'
+    redirect_to user_groups_url, notice: 'Group was successfully left.'
   end
 
   private

--- a/app/controllers/user_groups_controller.rb
+++ b/app/controllers/user_groups_controller.rb
@@ -51,6 +51,6 @@ class UserGroupsController < ApplicationController
   end
 
   def user_group_params
-    params.require(:user_group).permit(:name, :description).merge(user_id: current_user.id)
+    params.require(:user_group).permit(:name, :description, :visibility, user_ids: []).merge(user_id: current_user.id)
   end
 end

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -6,11 +6,11 @@ class DataSource < ApplicationRecord
 
   validates :user, :name, :description, presence: true
 
-  scope :by_name, -> { order('lower(name)') }
+  scope :by_name, -> { order(:name) }
   scope :user, ->(user) { left_outer_joins(:data_source_accesses).where(user: user).references(:data_source_accesses) }
   scope :unrestricted, -> { left_outer_joins(:data_source_accesses).where(data_source_accesses: { id: nil }) }
   scope :restricted_but_accessible_by, lambda { |user|
     left_outer_joins(:data_source_accesses).where(data_source_accesses: { user_group: user.user_groups })
   }
-  scope :accessible_by, ->(user) { user(user).or(unrestricted).or(restricted_but_accessible_by(user)) }
+  scope :accessible_by, ->(user) { user(user).or(unrestricted).or(restricted_but_accessible_by(user)).distinct }
 end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -1,11 +1,20 @@
 class UserGroup < ApplicationRecord
+  VISIBILITY_TYPES = %w[public private].freeze
+
   has_many :memberships, dependent: :destroy
   has_many :data_source_accesses, dependent: :destroy
   has_many :users, through: :memberships
   has_many :data_sources, through: :data_source_accesses
   belongs_to :user
 
-  validates :user, :name, :description, presence: true
+  validates :user, :name, :description, :visibility, presence: true
+  validates :visibility, inclusion: { in: VISIBILITY_TYPES, message: '%{value} is not a valid visibility' }
 
-  scope :by_name, -> { order('lower(name)') }
+  scope :by_name, -> { order(:name) }
+  scope :user, ->(user) { left_outer_joins(:memberships).where(user: user).references(:memberships) }
+  scope :public_groups, -> { left_outer_joins(:memberships).where(visibility: 'public').references(:memberships) }
+  scope :private_but_accessible_by, lambda { |user|
+    left_outer_joins(:memberships).where(memberships: { user_group: user.user_groups })
+  }
+  scope :accessible_by, ->(user) { user(user).or(public_groups).or(private_but_accessible_by(user)).distinct }
 end

--- a/app/policies/user_group_policy.rb
+++ b/app/policies/user_group_policy.rb
@@ -6,4 +6,10 @@ class UserGroupPolicy < ApplicationPolicy
   def destroy?
     record.user == user
   end
+
+  class Scope < Scope
+    def resolve
+      scope.accessible_by user
+    end
+  end
 end

--- a/app/views/user_groups/_form.html.haml
+++ b/app/views/user_groups/_form.html.haml
@@ -7,7 +7,11 @@
           %li= message
 
   .form-group
-    = f.text_field :name, autofocus: true, class: 'form-control form-control-lg', placeholder: 'Name'
+    .row
+      .col
+        = f.text_field :name, autofocus: true, class: 'form-control form-control-lg', placeholder: 'Name'
+      .col-md-auto
+        = f.select :visibility, UserGroup::VISIBILITY_TYPES, {}, class: 'form-control form-control-lg'
   .form-group
     = f.text_area :description, rows: 15, class: 'form-control form-control-lg', placeholder: 'Description'
     %small.form-text.text-muted You can write Markdown in the description.

--- a/app/views/user_groups/edit.html.haml
+++ b/app/views/user_groups/edit.html.haml
@@ -38,3 +38,14 @@
           Once you delete a group, there is no going back. Please be certain.
         .col-md-auto
           = link_to 'Delete this group', @user_group, data: { confirm: "Are you sure?" }, method: :delete, remote: true, class: 'btn btn-light text-danger'
+      %hr
+      = form_with model: @user_group do |f|
+        .row
+          .col
+            %h6 Manage Users:
+            = f.collection_check_boxes :user_ids, User.all, :id, :name do |b|
+              .form-check.form-check-inline
+                = b.label(class: 'form-check-label') do
+                  = b.check_box(class: 'form-check-input') + link_to(b.text.titleize, b.object)
+          .col-md-auto
+            = f.submit 'Update Accessibility', class: 'btn btn-light text-danger'

--- a/db/migrate/20171204090232_add_visibility_to_user_group.rb
+++ b/db/migrate/20171204090232_add_visibility_to_user_group.rb
@@ -1,0 +1,6 @@
+class AddVisibilityToUserGroup < ActiveRecord::Migration[5.1]
+  def change
+    add_column :user_groups, :visibility, :string, null: false, default: 'public'
+    add_index :user_groups, :visibility
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171202085305) do
+ActiveRecord::Schema.define(version: 20171204090232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,8 +88,10 @@ ActiveRecord::Schema.define(version: 20171202085305) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", default: 1, null: false
+    t.string "visibility", default: "public", null: false
     t.index ["name"], name: "index_user_groups_on_name"
     t.index ["user_id"], name: "index_user_groups_on_user_id"
+    t.index ["visibility"], name: "index_user_groups_on_visibility"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/controllers/memberships_controller_test.rb
+++ b/test/controllers/memberships_controller_test.rb
@@ -23,6 +23,6 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
       delete user_group_membership_url(@user_group, @membership)
     end
 
-    assert_redirected_to user_group_url(@user_group)
+    assert_redirected_to user_groups_url
   end
 end

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -7,3 +7,7 @@ one:
 two:
   user: alice
   user_group: two
+
+three:
+  user: alice
+  user_group: four

--- a/test/fixtures/user_groups.yml
+++ b/test/fixtures/user_groups.yml
@@ -9,8 +9,22 @@ two:
   name: user_group_name_two
   description: user_group_description_two
   user: bob
+  visibility: public
 
 three:
   name: user_group_name_three
   description: user_group_description_three
   user: bob
+  visibility: private
+
+four:
+  name: user_group_name_four
+  description: user_group_description_four
+  user: bob
+  visibility: private
+
+five:
+  name: user_group_name_five
+  description: user_group_description_five
+  user: alice
+  visibility: private

--- a/test/models/user_group_test.rb
+++ b/test/models/user_group_test.rb
@@ -16,4 +16,8 @@ class UserGroupTest < ActiveSupport::TestCase
   test 'invalid without description' do
     refute UserGroup.new(user: users('alice'), name: 'test').valid?
   end
+
+  test 'invalid without correct visibility' do
+    refute UserGroup.new(user: users('alice'), name: 'test', description: 'test', visibility: 'test').valid?
+  end
 end

--- a/test/policies/user_group_policy_test.rb
+++ b/test/policies/user_group_policy_test.rb
@@ -20,4 +20,20 @@ class UserGroupPolicyTest < ActiveSupport::TestCase
   test 'cannot destroy not owned user groups' do
     refute_permit @user, user_groups(:two), :destroy?
   end
+
+  test 'can access public user groups' do
+    assert_permit @user, user_groups(:two), :show?
+  end
+
+  test 'cannot access private user groups' do
+    refute_permit @user, user_groups(:three), :show?
+  end
+
+  test 'can access private user groups if member' do
+    assert_permit @user, user_groups(:four), :show?
+  end
+
+  test 'can access private user groups if owned' do
+    assert_permit @user, user_groups(:five), :show?
+  end
 end


### PR DESCRIPTION
When group is **private** the group owner has to add users manually to the group from the settings page and non-members cannot access the group.