### PR TITLE
add data reports

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -34,3 +34,7 @@ document.addEventListener('ajax:complete',function (event) {
     Turbolinks.visit(referrer, { action: 'restore' })
   }
 }, false)
+
+document.addEventListener('click', function(e) {
+  if (e.target.classList.contains('print-link')) window.print()
+})

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,0 +1,5 @@
+@media print {
+  nav, .nav, .btn {
+    display: none !important;
+  }
+}

--- a/app/controllers/data_report_requests_controller.rb
+++ b/app/controllers/data_report_requests_controller.rb
@@ -1,0 +1,13 @@
+class DataReportRequestsController < ApplicationController
+  before_action :set_data_report
+
+  def index
+    @data_requests = DataRequest.order(id: :desc).includes(data_endpoint: :data_source)
+  end
+
+  private
+
+  def set_data_report
+    @data_report = DataReport.find params[:data_report_id]
+  end
+end

--- a/app/controllers/data_reports_controller.rb
+++ b/app/controllers/data_reports_controller.rb
@@ -1,0 +1,54 @@
+class DataReportsController < ApplicationController
+  before_action :set_data_report, only: %i[show edit update destroy]
+
+  def index
+    @data_reports = policy_scope(DataReport).by_name.includes(:user)
+  end
+
+  def show
+    authorize @data_report
+  end
+
+  def new
+    @data_report = DataReport.new
+  end
+
+  def edit
+    authorize @data_report
+  end
+
+  def create
+    @data_report = DataReport.new(data_report_params)
+
+    if @data_report.save
+      redirect_to @data_report, notice: 'Data report was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  def update
+    authorize @data_report
+    if @data_report.update(data_report_params)
+      redirect_back fallback_location: edit_data_report_url(@data_report), notice: 'Data report was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    authorize @data_report
+    @data_report.destroy
+    redirect_to data_reports_url, notice: 'Data report was successfully destroyed.'
+  end
+
+  private
+
+  def set_data_report
+    @data_report = DataReport.find params[:id]
+  end
+
+  def data_report_params
+    params.require(:data_report).permit(:name, :body).merge(user_id: current_user.id)
+  end
+end

--- a/app/controllers/data_request_reports_controller.rb
+++ b/app/controllers/data_request_reports_controller.rb
@@ -1,0 +1,32 @@
+class DataRequestReportsController < ApplicationController
+  before_action :set_data_request
+  before_action :set_data_report, only: :update
+
+  def index
+    @data_reports = policy_scope(DataReport).by_name.includes(:user)
+  end
+
+  def update
+    authorize @data_report
+    if @data_report.update(body: render_to_string(layout: false, formats: :text))
+      redirect_to @data_report, notice: 'Data report was successfully updated.'
+    else
+      redirect_back(
+        fallback_location: url_for([@data_source, @data_endpoint, @data_request, :data_request_reports]),
+        flash: { error: @data_report.errors.full_messages.to_sentence }
+      )
+    end
+  end
+
+  private
+
+  def set_data_request
+    @data_source = DataSource.find params[:data_source_id]
+    @data_endpoint = DataEndpoint.find params[:data_endpoint_id]
+    @data_request = DataRequest.find params[:data_request_id]
+  end
+
+  def set_data_report
+    @data_report = DataReport.find params[:id]
+  end
+end

--- a/app/models/data_report.rb
+++ b/app/models/data_report.rb
@@ -1,0 +1,10 @@
+class DataReport < ApplicationRecord
+  belongs_to :user
+
+  validates :user, :name, :body, presence: true
+
+  delegate :name, to: :user, prefix: true
+
+  scope :by_name, -> { order(:name) }
+  scope :accessible_by, ->(_) { all }
+end

--- a/app/policies/data_report_policy.rb
+++ b/app/policies/data_report_policy.rb
@@ -1,0 +1,16 @@
+class DataReportPolicy < ApplicationPolicy
+  def update?
+    user.admin? || record.user == user
+  end
+
+  def destroy?
+    user.admin? || record.user == user
+  end
+
+  class Scope < Scope
+    def resolve
+      return scope if user.admin?
+      scope.accessible_by user
+    end
+  end
+end

--- a/app/views/data_report_requests/index.html.haml
+++ b/app/views/data_report_requests/index.html.haml
@@ -1,0 +1,28 @@
+%nav{role: 'navigation'}
+  %ol.breadcrumb
+    %li.breadcrumb-item= link_to t(:index, scope: :data_report), data_reports_path
+    %li.breadcrumb-item= link_to @data_report.name.titleize, @data_report
+    %li.breadcrumb-item.active= t(:index, scope: :data_report_request)
+
+.row
+  .col
+    %h1.display-5= @data_report.name.titleize
+  .col-md-auto
+    .mt-2
+      = link_to 'Print', '', class: 'btn btn btn-outline-success print-link'
+
+.nav.nav-tabs
+  %li.nav-item
+    = link_to t(:show, scope: :data_report), @data_report, class: 'nav-link'
+  %li.nav-item
+    %span.nav-link.active= t(:index, scope: :data_report_request)
+  %li.nav-item
+    = link_to t(:edit, scope: :data_report), [:edit, @data_report], class: 'nav-link'
+
+.mb-3
+
+- if @data_requests.length > 0
+  = render layout: 'data_requests/table', locals: {data_requests: @data_requests} do |data_request|
+    = link_to "#{t(:index, scope: :data_report_request)} ##{data_request.id}", data_source_data_endpoint_data_request_data_request_report_path(data_request.data_source, data_request.data_endpoint, data_request, @data_report), method: :put
+- else
+  No requests found...

--- a/app/views/data_reports/_form.html.haml
+++ b/app/views/data_reports/_form.html.haml
@@ -1,0 +1,15 @@
+= form_with model: @data_report do |f|
+  - if @data_report.errors.any?
+    #error_explanation
+      %h2= "#{pluralize(@data_report.errors.count, "error")} prohibited this report from being saved:"
+      %ul
+        - @data_report.errors.full_messages.each do |message|
+          %li= message
+
+  .form-group
+    = f.text_field :name, autofocus: true, class: 'form-control form-control-lg', placeholder: 'Name'
+  .form-group
+    = f.text_area :body, rows: 15, class: 'form-control', placeholder: 'Description'
+    %small.form-text.text-muted You can write Markdown in the body.
+  .form-group
+    = f.submit 'Save', class: 'btn btn-lg btn-light'

--- a/app/views/data_reports/_table.html.haml
+++ b/app/views/data_reports/_table.html.haml
@@ -1,0 +1,12 @@
+%table.table.table-striped
+  %thead
+    %tr
+      %th Report
+      %th Created by
+      %th Last modified
+  %tbody
+    - data_reports.each do |data_report|
+      %tr
+        %td= yield data_report
+        %td= link_to data_report.user_name, data_report.user
+        %td= l data_report.updated_at

--- a/app/views/data_reports/edit.html.haml
+++ b/app/views/data_reports/edit.html.haml
@@ -1,0 +1,33 @@
+%nav{role: 'navigation'}
+  %ol.breadcrumb
+    %li.breadcrumb-item= link_to t(:index, scope: :data_report), data_reports_path
+    %li.breadcrumb-item= link_to @data_report.name.titleize, @data_report
+    %li.breadcrumb-item.active= t(:edit, scope: :data_report)
+
+%h1.display-5
+  = @data_report.name.titleize
+
+.nav.nav-tabs
+  %li.nav-item
+    = link_to t(:show, scope: :data_report), @data_report, class: 'nav-link'
+  %li.nav-item
+    = link_to t(:index, scope: :data_report_request), [@data_report, :data_report_requests], class: 'nav-link'
+  %li.nav-item
+    %span.nav-link.active= t(:edit, scope: :data_report)
+
+.mb-3
+
+= render 'form'
+
+.mb-5
+
+%h1.card-title.display-6.text-danger Danger Zone
+.card.border-danger
+  .card-body
+    %p.card-text
+      .row
+        .col
+          %h6 Delete this report
+          Once you delete a report, there is no going back. Please be certain.
+        .col-md-auto
+          = link_to 'Delete this report', @data_report, data: { confirm: "Are you sure?" }, method: :delete, remote: true, class: 'btn btn-light text-danger'

--- a/app/views/data_reports/index.html.haml
+++ b/app/views/data_reports/index.html.haml
@@ -1,0 +1,13 @@
+.row
+  .col
+    %h1.display-4
+      = t(:index, scope: :data_report)
+  .col-md-auto
+    .mt-3
+    = link_to t(:new, scope: :data_report), new_data_report_path, class: 'btn btn-outline-success'
+
+- if @data_reports.length > 0
+  = render layout: 'table', locals: {data_reports: @data_reports} do |data_report|
+    = link_to data_report.name.titleize, data_report
+- else
+  No reports found...

--- a/app/views/data_reports/new.html.haml
+++ b/app/views/data_reports/new.html.haml
@@ -1,0 +1,8 @@
+%nav{role: 'navigation'}
+  %ol.breadcrumb
+    %li.breadcrumb-item= link_to t(:index, scope: :data_report), data_reports_path
+    %li.breadcrumb-item.active= t(:new, scope: :data_report)
+
+%h1.display-5= t(:new, scope: :data_report)
+
+= render 'form'

--- a/app/views/data_reports/show.html.haml
+++ b/app/views/data_reports/show.html.haml
@@ -1,0 +1,24 @@
+%nav{role: 'navigation'}
+  %ol.breadcrumb
+    %li.breadcrumb-item= link_to t(:index, scope: :data_report), data_reports_path
+    %li.breadcrumb-item.active= @data_report.name.titleize
+
+.row
+  .col
+    %h1.display-5= @data_report.name.titleize
+  .col-md-auto
+    .mt-2
+      = link_to 'Print', '', class: 'btn btn btn-outline-success print-link'
+
+.nav.nav-tabs
+  %li.nav-item
+    %span.nav-link.active= t(:show, scope: :data_report)
+  - if policy(@data_report).update?
+    %li.nav-item
+      = link_to t(:index, scope: :data_report_request), [@data_report, :data_report_requests], class: 'nav-link'
+    %li.nav-item
+      = link_to t(:edit, scope: :data_report), [:edit, @data_report], class: 'nav-link'
+
+.mb-3
+
+= render_markdown @data_report.body

--- a/app/views/data_request_reports/index.html.haml
+++ b/app/views/data_request_reports/index.html.haml
@@ -6,7 +6,7 @@
     %li.breadcrumb-item= link_to @data_endpoint.name.titleize, [@data_source, @data_endpoint]
     %li.breadcrumb-item= link_to t(:index, scope: :data_request), [@data_source, @data_endpoint, :data_requests]
     %li.breadcrumb-item= link_to "##{@data_request.id}", [@data_source, @data_endpoint, @data_request]
-    %li.breadcrumb-item.active= t(:index, scope: :data_request_diff)
+    %li.breadcrumb-item.active= t(:index, scope: :data_request_report)
 
 %h1.display-5= @data_source.name.titleize
 
@@ -25,14 +25,14 @@
   %li.nav-item
     = link_to t(:show, scope: :data_request), [@data_source, @data_endpoint, @data_request], class: 'nav-link'
   %li.nav-item
-    %span.nav-link.active= t(:index, scope: :data_request_diff)
+    = link_to t(:index, scope: :data_request_diff), [@data_source, @data_endpoint, @data_request, :data_request_diffs], class: 'nav-link'
   %li.nav-item
-    = link_to t(:index, scope: :data_request_report), [@data_source, @data_endpoint, @data_request, :data_request_reports], class: 'nav-link'
+    %span.nav-link.active= t(:index, scope: :data_request_report)
 
 .mb-3
 
-- if @data_requests.length > 0
-  = render layout: 'data_requests/table', locals: {data_requests: @data_requests} do |data_request_compared|
-    = link_to "#{t(:index, scope: :data_request_diff)} Request ##{data_request_compared.id}", data_source_data_endpoint_data_request_data_request_diff_path(@data_source, @data_endpoint, @data_request, data_request_compared)
+- if @data_reports.length > 0
+  = render layout: 'data_reports/table', locals: {data_reports: @data_reports} do |data_report|
+    = link_to "#{t(:index, scope: :data_request_report)} #{data_report.name}", data_source_data_endpoint_data_request_data_request_report_path(@data_source, @data_endpoint, @data_request, data_report), method: :put
 - else
   No requests found...

--- a/app/views/data_request_reports/update.text.haml
+++ b/app/views/data_request_reports/update.text.haml
@@ -1,0 +1,15 @@
+= "#{@data_report.body}\n".html_safe
+
+**#{@data_request.method}** #{@data_request.url}
+
+- if @data_request.params.present?
+  \###### Params
+  ```json
+  = JSON.pretty_generate(@data_request.params).html_safe
+  ```
+
+- if @data_request.response.present?
+  \###### Response
+  ```json
+  = JSON.pretty_generate(@data_request.response).html_safe
+  ```

--- a/app/views/data_requests/show.html.haml
+++ b/app/views/data_requests/show.html.haml
@@ -25,6 +25,8 @@
     %span.nav-link.active= t(:show, scope: :data_request)
   %li.nav-item
     = link_to t(:index, scope: :data_request_diff), [@data_source, @data_endpoint, @data_request, :data_request_diffs], class: 'nav-link'
+  %li.nav-item
+    = link_to t(:index, scope: :data_request_report), [@data_source, @data_endpoint, @data_request, :data_request_reports], class: 'nav-link'
 
 - if @data_request.params.present?
   .mb-3

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,6 +28,8 @@
               = link_to 'Groups', user_groups_path, class: 'nav-link'
             = nav_link :data_sources do
               = link_to 'Data Sources', data_sources_path, class: 'nav-link'
+            = nav_link :data_reports do
+              = link_to 'Reports', data_reports_path, class: 'nav-link'
           = search_form_for @q, class: 'form-inline my-2 my-lg-0' do |f|
             .input-group
               = f.text_field :name_cont, class: 'form-control', placeholder: 'Search Data', type: 'search'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,11 @@ en:
       default: ! '%m/%d/%y %H:%M'
       short: ! '%m/%d/%y'
       detailed: ! '%m/%d/%y %H:%M:%S'
+  data_report:
+    index: 'Reports'
+    new: 'New Report'
+    show: 'Preview'
+    edit: 'Edit'
   data_source:
     index: 'Data Sources'
     new: 'New Data Source'
@@ -51,7 +56,11 @@ en:
     new: 'New Request'
     show: 'Overview'
   data_request_diff:
-    index: 'Diff with'
+    index: 'Compare with'
+  data_request_report:
+    index: 'Add to'
+  data_report_request:
+    index: 'Add Requests'
   user_group:
     index: 'Groups'
     new: 'New Group'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,12 @@ Rails.application.routes.draw do
     resources :data_endpoints do
       resources :data_requests, only: %i[index show create new] do
         resources :data_request_diffs, only: %i[index show]
+        resources :data_request_reports, only: %i[index update]
       end
     end
+  end
+
+  resources :data_reports do
+    resources :data_report_requests, only: :index
   end
 end

--- a/db/migrate/20171214095108_create_data_reports.rb
+++ b/db/migrate/20171214095108_create_data_reports.rb
@@ -1,0 +1,11 @@
+class CreateDataReports < ActiveRecord::Migration[5.1]
+  def change
+    create_table :data_reports do |t|
+      t.string :name, null: false, index: true
+      t.text :body
+      t.references :user, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171206092620) do
+ActiveRecord::Schema.define(version: 20171214095108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,16 @@ ActiveRecord::Schema.define(version: 20171206092620) do
     t.index ["description"], name: "index_data_endpoints_on_description"
     t.index ["name"], name: "index_data_endpoints_on_name"
     t.index ["user_id"], name: "index_data_endpoints_on_user_id"
+  end
+
+  create_table "data_reports", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_data_reports_on_name"
+    t.index ["user_id"], name: "index_data_reports_on_user_id"
   end
 
   create_table "data_requests", force: :cascade do |t|
@@ -129,6 +139,7 @@ ActiveRecord::Schema.define(version: 20171206092620) do
 
   add_foreign_key "data_endpoints", "data_sources"
   add_foreign_key "data_endpoints", "users"
+  add_foreign_key "data_reports", "users"
   add_foreign_key "data_requests", "data_endpoints"
   add_foreign_key "data_requests", "users"
   add_foreign_key "data_source_accesses", "data_sources"

--- a/test/controllers/data_report_requests_controller_test.rb
+++ b/test/controllers/data_report_requests_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class DataReportRequestsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in users(:alice)
+    @data_report = data_reports(:one)
+  end
+
+  test 'should get index' do
+    get url_for([@data_report, :data_report_requests])
+    assert_response :success
+  end
+end

--- a/test/controllers/data_reports_controller_test.rb
+++ b/test/controllers/data_reports_controller_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class DataReportsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in users(:alice)
+    @data_report = data_reports(:one)
+  end
+
+  test 'should get index' do
+    get data_reports_url
+    assert_response :success
+  end
+
+  test 'should get new' do
+    get new_data_report_url
+    assert_response :success
+  end
+
+  test 'should create data_report' do
+    assert_difference('DataReport.count') do
+      post data_reports_url, params: { data_report: { body: @data_report.body, name: @data_report.name } }
+    end
+
+    assert_redirected_to data_report_url(DataReport.last)
+  end
+
+  test 'should show data_report' do
+    get data_report_url(@data_report)
+    assert_response :success
+  end
+
+  test 'should get edit' do
+    get edit_data_report_url(@data_report)
+    assert_response :success
+  end
+
+  test 'should update data_report' do
+    patch data_report_url(@data_report), params: { data_report: { body: @data_report.body, name: @data_report.name } }
+    assert_redirected_to edit_data_report_url(@data_report)
+  end
+
+  test 'should destroy data_report' do
+    assert_difference('DataReport.count', -1) do
+      delete data_report_url(@data_report)
+    end
+
+    assert_redirected_to data_reports_url
+  end
+end

--- a/test/controllers/data_request_diffs_controller_test.rb
+++ b/test/controllers/data_request_diffs_controller_test.rb
@@ -6,34 +6,23 @@ class DataRequestDiffsControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in users(:alice)
     @data_request = data_requests(:one)
+    @data_request_compared = data_requests(:four)
     @data_endpoint = @data_request.data_endpoint
     @data_source = @data_endpoint.data_source
   end
 
   test 'should get index' do
-    get url_for([@data_source, @data_endpoint, :data_requests])
+    get url_for [@data_source, @data_endpoint, @data_request, :data_request_diffs]
     assert_response :success
   end
 
-  test 'should get new' do
-    get url_for([:new, @data_source, @data_endpoint, :data_request])
-    assert_response :success
-  end
-
-  test 'should create data_request' do
-    assert_difference('DataRequest.count') do
-      post url_for([@data_source, @data_endpoint, :data_requests]), params: {
-        data_request: {
-          params: @data_request.params, response: @data_request.response, url: @data_request.url
-        }
-      }
-    end
-
-    assert_redirected_to url_for([@data_source, @data_endpoint, DataRequest.last])
-  end
-
-  test 'should show data_request' do
-    get url_for([@data_source, @data_endpoint, @data_request])
+  test 'should show data request diff' do
+    get data_source_data_endpoint_data_request_data_request_diff_path(
+      @data_source,
+      @data_endpoint,
+      @data_request,
+      @data_request_compared
+    )
     assert_response :success
   end
 end

--- a/test/controllers/data_request_reports_controller_test.rb
+++ b/test/controllers/data_request_reports_controller_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class DataRequestReportsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in users(:alice)
+    @data_report = data_reports(:one)
+    @data_request = data_requests(:one)
+    @data_endpoint = @data_request.data_endpoint
+    @data_source = @data_endpoint.data_source
+  end
+
+  test 'should get index' do
+    get url_for([@data_source, @data_endpoint, @data_request, :data_request_reports])
+    assert_response :success
+  end
+
+  test 'should update data report' do
+    initial_data_report = @data_report.dup
+    put data_source_data_endpoint_data_request_data_request_report_path(@data_source, @data_endpoint, @data_request, @data_report)
+    assert_equal @data_report.reload.body, DataRequestReportsController.render(
+      :update,
+      layout: false,
+      formats: :text,
+      assigns: { data_report: initial_data_report, data_request: @data_request }
+    )
+    assert_redirected_to @data_report
+  end
+end

--- a/test/fixtures/data_reports.yml
+++ b/test/fixtures/data_reports.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: data_report_name_one
+  body: data_report_body_one
+  user: alice
+
+two:
+  name: data_report_name_two
+  body: data_report_body_two
+  user: bob

--- a/test/models/data_report_test.rb
+++ b/test/models/data_report_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class DataReportTest < ActiveSupport::TestCase
+  test 'valid' do
+    assert data_reports(:one).valid?
+  end
+
+  test 'invalid without user' do
+    refute DataReport.new(name: 'test', body: 'test').valid?
+  end
+
+  test 'invalid without name' do
+    refute DataReport.new(user: users(:alice), body: 'test').valid?
+  end
+
+  test 'invalid without body' do
+    refute DataReport.new(user: users(:alice), name: 'test').valid?
+  end
+end

--- a/test/system/data_report_requests_test.rb
+++ b/test/system/data_report_requests_test.rb
@@ -1,0 +1,16 @@
+require 'application_system_test_case'
+
+class DataReportRequestsTest < ApplicationSystemTestCase
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in users(:alice)
+    @data_report = data_reports(:one)
+  end
+
+  test 'visiting the index page' do
+    visit url_for [@data_report, :data_report_requests]
+    assert_selector 'h1', text: @data_report.name.titleize
+    assert_selector 'table'
+  end
+end

--- a/test/system/data_reports_test.rb
+++ b/test/system/data_reports_test.rb
@@ -1,0 +1,26 @@
+require 'application_system_test_case'
+
+class DataReportsTest < ApplicationSystemTestCase
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @data_report = data_reports(:one)
+    sign_in users(:alice)
+  end
+
+  test 'visiting the index page' do
+    visit data_reports_url
+    assert_selector 'h1', text: 'Reports'
+    assert_selector 'table'
+  end
+
+  test 'visiting a data report page' do
+    visit data_report_url @data_report
+    assert_selector 'h1', text: @data_report.name.titleize
+  end
+
+  test 'visiting a data report edit page' do
+    visit edit_data_report_url @data_report
+    assert_selector 'form'
+  end
+end

--- a/test/system/data_request_reports_test.rb
+++ b/test/system/data_request_reports_test.rb
@@ -1,0 +1,20 @@
+require 'application_system_test_case'
+
+class DataRequestReportsTest < ApplicationSystemTestCase
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in users(:alice)
+    @data_request = data_requests(:one)
+    @data_report = data_reports(:one)
+    @data_endpoint = @data_request.data_endpoint
+    @data_source = @data_endpoint.data_source
+  end
+
+  test 'visiting the index page' do
+    visit url_for [@data_source, @data_endpoint, @data_request, :data_request_reports]
+    assert_selector 'h1', text: @data_source.name.titleize
+    assert_selector 'h1', text: @data_endpoint.name.titleize
+    assert_selector 'table'
+  end
+end


### PR DESCRIPTION
- a report is composed of a name and a body.
- support to print (and save as PDF) a report
- add requests to report automatically following this format:

----------------------

**GET** http://example.com
###### Params
```json
{
  "param1": "value1"
}
```
###### Response
```json
{
  "field1": "value1"
}
```
----------------------

**Report preview**
<img width="1123" alt="1" src="https://user-images.githubusercontent.com/6973663/34004873-7204dde2-e0f9-11e7-8159-53ce54a26958.png">
**Report print**
<img width="1152" alt="2" src="https://user-images.githubusercontent.com/6973663/34004875-7268c104-e0f9-11e7-9b30-c7f11ffd9a5c.png">
**Add requests to report**
<img width="1124" alt="3" src="https://user-images.githubusercontent.com/6973663/34004876-72b133b2-e0f9-11e7-9e2a-fda84ccff742.png">
<img width="1121" alt="4" src="https://user-images.githubusercontent.com/6973663/34004878-72d3d066-e0f9-11e7-99ae-84f94c673c75.png">
